### PR TITLE
pruning 9156

### DIFF
--- a/mafia/data/raretiles.json
+++ b/mafia/data/raretiles.json
@@ -772,7 +772,6 @@
   { "minute": 9125, "row": 3, "column": 4 },
   { "minute": 9139, "row": 9, "column": 8 },
   { "minute": 9150, "row": 10, "column": 3 },
-  { "minute": 9156, "row": 4, "column": 2 },
   { "minute": 9156, "row": 10, "column": 1 },
   { "minute": 9163, "row": 7, "column": 0 },
   { "minute": 9172, "row": 7, "column": 9 },


### PR DESCRIPTION
received bug report today re: unexpected tile behavior

![image](https://user-images.githubusercontent.com/8014761/150442176-7c1932bc-ca7b-4389-82cd-11af8a11fe48.png)

given the rules outlined on the wiki, this shouldn't be possible assuming the tile was uncombed and rare; it should've produced either driftwood or one of the rarey-rares. pruning tile due to this report. 