### PR TITLE
Start avoiding known false rares

### DIFF
--- a/src/combo.ts
+++ b/src/combo.ts
@@ -119,7 +119,10 @@ function _comb(tile: BeachTile): void {
     // Here we make sure that the tile we were going to comb wasn't actually rough sand
     // This uses `hasTwinkleVision` which was added in r27618, but this is not required.
     if (get("hasTwinkleVision", false) && rareRow[column] === "r") {
-      print("Our rare tile is uncombed, but it was actually rough sand.", HIGHLIGHT);
+      print(
+        "Although our rare tile was uncombed, it is actually rough sand. Lets avoid this tile in the future.",
+        HIGHLIGHT
+      );
       // Note that it is not a rare tile, then invoke a function to add it to the false rares
       addFalseRare(tile);
     }

--- a/src/combo.ts
+++ b/src/combo.ts
@@ -46,10 +46,10 @@ function getFalseRares(): BeachTile[] {
   const knownFalseRares = getProperty("combo_false_rares")
     .split(";")
     .filter((s) => s.length > 0);
-  const beachTiles: BeachTile[] = knownFalseRares.map((s) => {
-    const [minute, row, col] = s.split(",").map((s) => toInt(s));
+  const beachTiles = knownFalseRares.map((s): BeachTile => {
+    const [minute, row, column] = s.split(",").map((s) => toInt(s));
 
-    return { minute: minute, row: row, column: col };
+    return { minute, row, column };
   });
 
   return beachTiles;

--- a/src/combo.ts
+++ b/src/combo.ts
@@ -11,7 +11,6 @@ import {
   print,
   runChoice,
   setProperty,
-  toInt,
 } from "kolmafia";
 import { $items, get, property, Session, set, sinceKolmafiaRevision } from "libram";
 

--- a/src/combo.ts
+++ b/src/combo.ts
@@ -117,7 +117,8 @@ function _comb(tile: BeachTile): void {
   const rareRow = layout.get(row);
   if (rareRow) {
     // Here we make sure that the tile we were going to comb wasn't actually rough sand
-    if (rareRow[column] === "r") {
+    // This uses `hasTwinkleVision` which was added in r27618, but this is not required.
+    if (get("hasTwinkleVision", false) && rareRow[column] === "r") {
       print("Our rare tile is uncombed, but it was actually rough sand.", HIGHLIGHT);
       // Note that it is not a rare tile, then invoke a function to add it to the false rares
       addFalseRare(tile);

--- a/src/combo.ts
+++ b/src/combo.ts
@@ -35,18 +35,24 @@ const infrequentItemNames =
     (item) => item.name.toLowerCase()
   );
 
-function getFalseRares(): BeachTile[] {
+function parseFalseRares(): BeachTile[] {
   // Get the property and split it by the divider of ;
   const knownFalseRares = getProperty("combo_false_rares")
     .split(";")
     .filter((s) => s.length > 0);
   const beachTiles = knownFalseRares.map((s): BeachTile => {
-    const [minute, row, column] = s.split(",").map((s) => toInt(s));
+    const [minute, row, column] = s.split(",").map(Number);
 
     return { minute, row, column };
   });
 
   return beachTiles;
+};
+
+let falseRares: BeachTile[];
+function getFalseRares(): BeachTle[] {
+  if (!falseRares) falseRares = parseFalseRares();
+  return falseRares
 }
 
 function isFalseRare(tile: BeachTile): boolean {

--- a/src/combo.ts
+++ b/src/combo.ts
@@ -49,11 +49,8 @@ function getFalseRares(): BeachTile[] {
   return beachTiles;
 }
 
-// A list of tiles we know are false rares
-const knownFalseRares = getFalseRares();
-
 function isFalseRare(tile: BeachTile): boolean {
-  return knownFalseRares.some(
+  return getFalseRares().some(
     (t) => tile.minute === t.minute && tile.row === t.row && tile.column === t.column
   );
 }
@@ -64,6 +61,8 @@ function addFalseRare(tile: BeachTile) {
   if (isFalseRare(tile)) {
     return;
   }
+
+  const knownFalseRares = getFalseRares();
 
   // Push it to the list of known false rares
   knownFalseRares.push(tile);

--- a/src/combo.ts
+++ b/src/combo.ts
@@ -46,12 +46,12 @@ function parseFalseRares(): BeachTile[] {
   });
 
   return beachTiles;
-};
+}
 
 let falseRares: BeachTile[];
 function getFalseRares(): BeachTile[] {
   if (!falseRares) falseRares = parseFalseRares();
-  return falseRares
+  return falseRares;
 }
 
 function isFalseRare(tile: BeachTile): boolean {

--- a/src/combo.ts
+++ b/src/combo.ts
@@ -49,7 +49,7 @@ function parseFalseRares(): BeachTile[] {
 };
 
 let falseRares: BeachTile[];
-function getFalseRares(): BeachTle[] {
+function getFalseRares(): BeachTile[] {
   if (!falseRares) falseRares = parseFalseRares();
   return falseRares
 }

--- a/src/combo.ts
+++ b/src/combo.ts
@@ -13,7 +13,7 @@ import {
   setProperty,
   toInt,
 } from "kolmafia";
-import { get, property, Session, set, sinceKolmafiaRevision } from "libram";
+import { $items, get, property, Session, set, sinceKolmafiaRevision } from "libram";
 
 // Gotta print in a legible colour.
 const HIGHLIGHT = isDarkMode() ? "yellow" : "blue";
@@ -30,16 +30,10 @@ type BeachTile = { minute: number; row: number; column: number };
 const rareTiles: BeachTile[] = JSON.parse(fileToBuffer("raretiles.json"));
 
 // A list of all the common items found in infreqeunt twinkles to detect when we actually combed an infrequent tile instead of a rare
-const infrequentItemNames: string[] = [
-  "sand dollar",
-  "dull fish scale",
-  "rough fish scale",
-  "lucky rabbitfish fin",
-  "spearfish fishing spear",
-  "Waders",
-  "pristine fish scale",
-  "piece of coral",
-].map((s) => s.toLowerCase());
+const infrequentItemNames =
+  $items`sand dollar, dull fish scale, rough fish scale, lucky rabbitfish fin, spearfish fishing spear, waders, pristine fish scale, piece of coral`.map(
+    (item) => item.name.toLowerCase()
+  );
 
 function getFalseRares(): BeachTile[] {
   // Get the property and split it by the divider of ;


### PR DESCRIPTION
Some rares in our list are not actually rare tiles due to bad data. This would ideally be uploaded somewhere, but for now we can avoid it and log it on a per-user basis.